### PR TITLE
tighten styling of album name in chartlist

### DIFF
--- a/dist/lastfm-bulk-edit.user.js
+++ b/dist/lastfm-bulk-edit.user.js
@@ -530,14 +530,13 @@ function appendStyle() {
             }
 
             .${namespace}-chartlist-scrobbles .chartlist-album {
-                margin-top: 13px;
+                margin-top: 15px;
                 margin-bottom: -2px;
                 position: absolute;
-                left: 133px;
+                left: 134px;
                 width: 182px;
                 font-size:12px;
                 color:#999;
-                transform:translateY(1px);
             }
 
             .${namespace}-chartlist-scrobbles .chartlist-album::before {

--- a/dist/lastfm-bulk-edit.user.js
+++ b/dist/lastfm-bulk-edit.user.js
@@ -147,9 +147,6 @@ async function displayAlbumName(element) {
             const albumAnchor = document.createElement('a');
             albumAnchor.href = albumHref;
             albumAnchor.title = albumName;
-            albumAnchor.style.fontSize = '0.75rem';
-            albumAnchor.style.color = '#999';
-            albumAnchor.style.transform = 'translateY(1px)';
             albumAnchor.textContent = albumName;
             albumCell.appendChild(albumAnchor);
         }
@@ -536,8 +533,11 @@ function appendStyle() {
                 margin-top: 13px;
                 margin-bottom: -2px;
                 position: absolute;
-                left: 133.5px;
-                width: 182.41px;
+                left: 133px;
+                width: 182px;
+                font-size:12px;
+                color:#999;
+                transform:translateY(1px);
             }
 
             .${namespace}-chartlist-scrobbles .chartlist-album::before {

--- a/dist/lastfm-bulk-edit.user.js
+++ b/dist/lastfm-bulk-edit.user.js
@@ -147,6 +147,9 @@ async function displayAlbumName(element) {
             const albumAnchor = document.createElement('a');
             albumAnchor.href = albumHref;
             albumAnchor.title = albumName;
+            albumAnchor.style.fontSize = '0.75rem';
+            albumAnchor.style.color = '#999';
+            albumAnchor.style.transform = 'translateY(1px)';
             albumAnchor.textContent = albumName;
             albumCell.appendChild(albumAnchor);
         }

--- a/src/features/display-album-name.ts
+++ b/src/features/display-album-name.ts
@@ -40,9 +40,6 @@ export async function displayAlbumName(element: Element) {
             const albumAnchor = document.createElement('a');
             albumAnchor.href = albumHref;
             albumAnchor.title = albumName;
-            albumAnchor.style.fontSize = '0.75rem';
-            albumAnchor.style.color = '#999';
-            albumAnchor.style.transform = 'translateY(1px)';
             albumAnchor.textContent = albumName;
             albumCell.appendChild(albumAnchor);
         } else {

--- a/src/features/display-album-name.ts
+++ b/src/features/display-album-name.ts
@@ -40,6 +40,9 @@ export async function displayAlbumName(element: Element) {
             const albumAnchor = document.createElement('a');
             albumAnchor.href = albumHref;
             albumAnchor.title = albumName;
+            albumAnchor.style.fontSize = '0.75rem';
+            albumAnchor.style.color = '#999';
+            albumAnchor.style.transform = 'translateY(1px)';
             albumAnchor.textContent = albumName;
             albumCell.appendChild(albumAnchor);
         } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,14 +148,13 @@ function appendStyle() {
             }
 
             .${namespace}-chartlist-scrobbles .chartlist-album {
-                margin-top: 13px;
+                margin-top: 15px;
                 margin-bottom: -2px;
                 position: absolute;
-                left: 133px;
+                left: 134px;
                 width: 182px;
                 font-size:12px;
                 color:#999;
-                transform:translateY(1px);
             }
 
             .${namespace}-chartlist-scrobbles .chartlist-album::before {

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,8 +151,11 @@ function appendStyle() {
                 margin-top: 13px;
                 margin-bottom: -2px;
                 position: absolute;
-                left: 133.5px;
-                width: 182.41px;
+                left: 133px;
+                width: 182px;
+                font-size:12px;
+                color:#999;
+                transform:translateY(1px);
             }
 
             .${namespace}-chartlist-scrobbles .chartlist-album::before {


### PR DESCRIPTION
Some (very) minor styling tweaks to improve display of album name when displayed in the chartlist table.

<img width="792" alt="Screenshot 2023-08-07 at 19 05 38" src="https://github.com/RudeySH/lastfm-bulk-edit/assets/1922098/d75a4725-b9d9-4338-8902-1230bf674b62">